### PR TITLE
feat: Implement dashboard and pass details actions

### DIFF
--- a/frontend/gatepass_app/lib/presentation/my_passes/my_pass_details_screen.dart
+++ b/frontend/gatepass_app/lib/presentation/my_passes/my_pass_details_screen.dart
@@ -33,6 +33,7 @@ class _MyPassDetailsScreenState extends State<MyPassDetailsScreen> {
       );
       if (image != null) {
         final result = await ImageGallerySaver.saveImage(image);
+        if (!mounted) return;
         if (result['isSuccess']) {
           ScaffoldMessenger.of(context).showSnackBar(
             const SnackBar(content: Text('Pass saved to gallery')),
@@ -42,6 +43,7 @@ class _MyPassDetailsScreenState extends State<MyPassDetailsScreen> {
         }
       }
     } catch (e) {
+      if (!mounted) return;
       ScaffoldMessenger.of(context).showSnackBar(
         SnackBar(content: Text('Failed to save pass: $e')),
       );
@@ -72,6 +74,7 @@ class _MyPassDetailsScreenState extends State<MyPassDetailsScreen> {
         await Share.shareXFiles([xFile], text: passDetails);
       }
     } catch (e) {
+      if (!mounted) return;
       ScaffoldMessenger.of(context).showSnackBar(
         SnackBar(content: Text('Failed to share pass: $e')),
       );
@@ -97,6 +100,7 @@ class _MyPassDetailsScreenState extends State<MyPassDetailsScreen> {
         );
       }
     } catch (e) {
+      if (!mounted) return;
       ScaffoldMessenger.of(context).showSnackBar(
         SnackBar(content: Text('Failed to print pass: $e')),
       );


### PR DESCRIPTION
This commit introduces the following features:

- Implements the dashboard screen, fetching data from a new backend API endpoint to display gate pass statistics.
- Adds "Download", "Send", and "Print" buttons to the pass details screen, allowing you to save the pass as a PNG image, share it with other apps, or print it.

The backend API for the dashboard summary has also been created.

Additionally, this commit fixes a failing test in `widget_test.dart` by using generated mocks instead of manual mocks, which resolves a null safety issue.