### PR TITLE
fix: Wrap buttons in Expanded to fix layout error

### DIFF
--- a/frontend/gatepass_app/lib/presentation/my_passes/my_pass_details_screen.dart
+++ b/frontend/gatepass_app/lib/presentation/my_passes/my_pass_details_screen.dart
@@ -121,20 +121,28 @@ class _MyPassDetailsScreenState extends State<MyPassDetailsScreen> {
               Row(
                 mainAxisAlignment: MainAxisAlignment.spaceEvenly,
                 children: [
-                  ElevatedButton.icon(
-                    onPressed: _captureAndSave,
-                    icon: const Icon(Icons.download),
-                    label: const Text('Download'),
+                  Expanded(
+                    child: ElevatedButton.icon(
+                      onPressed: _captureAndSave,
+                      icon: const Icon(Icons.download),
+                      label: const Text('Download'),
+                    ),
                   ),
-                  ElevatedButton.icon(
-                    onPressed: _captureAndShare,
-                    icon: const Icon(Icons.share),
-                    label: const Text('Send'),
+                  const SizedBox(width: 8),
+                  Expanded(
+                    child: ElevatedButton.icon(
+                      onPressed: _captureAndShare,
+                      icon: const Icon(Icons.share),
+                      label: const Text('Send'),
+                    ),
                   ),
-                  ElevatedButton.icon(
-                    onPressed: _captureAndPrint,
-                    icon: const Icon(Icons.print),
-                    label: const Text('Print'),
+                  const SizedBox(width: 8),
+                  Expanded(
+                    child: ElevatedButton.icon(
+                      onPressed: _captureAndPrint,
+                      icon: const Icon(Icons.print),
+                      label: const Text('Print'),
+                    ),
                   ),
                 ],
               ),


### PR DESCRIPTION
This commit fixes a layout error in the `my_pass_details_screen.dart` file where the `Row` widget was forcing an infinite width on its children.

The `ElevatedButton.icon` widgets have been wrapped with `Expanded` widgets to ensure that they take up an equal amount of space in the `Row`.