### PR TITLE
feat: Add admin screen and use environment variables

### DIFF
--- a/backend/gatepass_project/settings/base.py
+++ b/backend/gatepass_project/settings/base.py
@@ -5,6 +5,9 @@ Base settings for the Gate Pass System backend.
 import os
 from pathlib import Path
 from datetime import timedelta
+from dotenv import load_dotenv
+
+load_dotenv()
 
 # Build paths inside the project like this: BASE_DIR / 'subdir'.
 BASE_DIR = Path(__file__).resolve().parent.parent.parent
@@ -202,6 +205,7 @@ SIMPLE_JWT = {
 
 # CORS settings for Flutter frontend (adjust as needed for production)
 CORS_ALLOW_ALL_ORIGINS = True # For development, very permissive
+ALLOWED_HOSTS = os.environ.get('ALLOWED_HOSTS', 'localhost,127.0.0.1').split(',')
 # CORS_ALLOWED_ORIGINS = [ # For production, list specific origins
 #     "http://localhost:8000", # Django dev server
 #     "http://localhost:5000", # Flutter web dev server (default)

--- a/frontend/gatepass_app/lib/config/app_config.dart
+++ b/frontend/gatepass_app/lib/config/app_config.dart
@@ -1,5 +1,6 @@
+import 'package:flutter_dotenv/flutter_dotenv.dart';
+
 class AppConfig {
-  static const String baseUrl =
-      // 'http://192.168.167.77:8000/api/'; // Your Django backend API URL
-      'http://127.0.0.1:8000';
+  static String get baseUrl =>
+      dotenv.env['BASE_URL'] ?? 'http://127.0.0.1:8000';
 }

--- a/frontend/gatepass_app/lib/main.dart
+++ b/frontend/gatepass_app/lib/main.dart
@@ -4,15 +4,19 @@ import 'package:flutter/material.dart';
 import 'package:gatepass_app/presentation/auth/login_screen.dart';
 import 'package:gatepass_app/presentation/home/home_screen.dart';
 import 'package:gatepass_app/presentation/reports/reports_screen.dart';
+import 'package:gatepass_app/presentation/admin/admin_screen.dart';
 import 'package:gatepass_app/core/api_client.dart';
 import 'package:gatepass_app/services/auth_service.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 
-void main() async {
+import 'package:flutter_dotenv/flutter_dotenv.dart';
+
+Future main() async {
+  await dotenv.load(fileName: ".env");
   WidgetsFlutterBinding.ensureInitialized();
   final sharedPreferences = await SharedPreferences.getInstance();
 
-  const String baseUrl = 'http://127.0.0.1:8000';
+  final String baseUrl = dotenv.env['BASE_URL'] ?? 'http://127.0.0.1:8000';
 
   // Initialize AuthService first with a temporary null for ApiClient
   final authService = AuthService(sharedPreferences, null);
@@ -106,6 +110,8 @@ class MyApp extends StatelessWidget {
             HomeScreen(apiClient: apiClient, authService: authService),
         '/reports': (context) =>
             ReportsScreen(apiClient: apiClient),
+        '/admin': (context) =>
+            AdminScreen(apiClient: apiClient, authService: authService),
       },
     );
   }

--- a/frontend/gatepass_app/lib/presentation/admin/admin_screen.dart
+++ b/frontend/gatepass_app/lib/presentation/admin/admin_screen.dart
@@ -1,0 +1,229 @@
+import 'package:flutter/material.dart';
+import 'package:gatepass_app/core/api_client.dart';
+import 'package:gatepass_app/services/auth_service.dart';
+import 'package:intl/intl.dart';
+import 'package:gatepass_app/presentation/my_passes/my_pass_details_screen.dart';
+
+class AdminScreen extends StatefulWidget {
+  final ApiClient apiClient;
+  final AuthService authService;
+
+  const AdminScreen({
+    super.key,
+    required this.apiClient,
+    required this.authService,
+  });
+
+  @override
+  State<AdminScreen> createState() => _AdminScreenState();
+}
+
+class _AdminScreenState extends State<AdminScreen> {
+  late final ApiClient _apiClient;
+  bool _isLoading = true;
+  String? _errorMessage;
+  List<Map<String, dynamic>> _allGatePasses = [];
+  List<Map<String, dynamic>> _filteredGatePasses = [];
+  String _selectedStatus = 'All';
+
+  @override
+  void initState() {
+    super.initState();
+    _apiClient = widget.apiClient;
+    _fetchAllGatePasses();
+  }
+
+  List<Map<String, dynamic>> _extractResults(dynamic response) {
+    if (response is Map<String, dynamic> &&
+        response.containsKey('results') &&
+        response['results'] is List) {
+      return List<Map<String, dynamic>>.from(response['results']);
+    } else if (response is List) {
+      return List<Map<String, dynamic>>.from(response);
+    }
+    return [];
+  }
+
+  Future<void> _fetchAllGatePasses() async {
+    setState(() {
+      _isLoading = true;
+      _errorMessage = null;
+    });
+    try {
+      final response = await _apiClient.get('api/gatepass/gatepasses/');
+      _allGatePasses = _extractResults(response);
+      _filteredGatePasses = _allGatePasses;
+    } catch (e) {
+      setState(() {
+        _errorMessage = 'Error loading gate passes: $e';
+      });
+    } finally {
+      setState(() {
+        _isLoading = false;
+      });
+    }
+  }
+
+  Future<void> _approvePass(int passId) async {
+    try {
+      await _apiClient.post('api/gatepass/gatepasses/$passId/approve/', {});
+      _fetchAllGatePasses();
+    } catch (e) {
+      ScaffoldMessenger.of(context).showSnackBar(
+        SnackBar(content: Text('Failed to approve pass: $e')),
+      );
+    }
+  }
+
+  Future<void> _rejectPass(int passId) async {
+    try {
+      await _apiClient.post('api/gatepass/gatepasses/$passId/reject/', {});
+      _fetchAllGatePasses();
+    } catch (e) {
+      ScaffoldMessenger.of(context).showSnackBar(
+        SnackBar(content: Text('Failed to reject pass: $e')),
+      );
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(
+        title: const Text('Admin - All Passes'),
+      ),
+      body: _buildBody(),
+    );
+  }
+
+  Widget _buildBody() {
+    if (_isLoading) {
+      return const Center(child: CircularProgressIndicator());
+    }
+
+    if (_errorMessage != null) {
+      return Center(
+        child: Padding(
+          padding: const EdgeInsets.all(16.0),
+          child: Column(
+            mainAxisAlignment: MainAxisAlignment.center,
+            children: [
+              Text(
+                'Error: $_errorMessage',
+                textAlign: TextAlign.center,
+                style: const TextStyle(color: Colors.red, fontSize: 16),
+              ),
+              const SizedBox(height: 20),
+              ElevatedButton(
+                onPressed: _fetchAllGatePasses,
+                child: const Text('Retry'),
+              ),
+            ],
+          ),
+        ),
+      );
+    }
+
+    if (_allGatePasses.isEmpty) {
+      return const Center(
+        child: Text('No gate passes found.'),
+      );
+    }
+
+    return Column(
+      children: [
+        _buildFilterBar(),
+        Expanded(
+          child: RefreshIndicator(
+            onRefresh: _fetchAllGatePasses,
+            child: ListView.builder(
+              padding: const EdgeInsets.all(16.0),
+              itemCount: _filteredGatePasses.length,
+              itemBuilder: (context, index) {
+                final pass = _filteredGatePasses[index];
+                return Card(
+                  margin: const EdgeInsets.symmetric(vertical: 8.0),
+                  child: ListTile(
+                    title: Text(
+                        'Purpose: ${pass['purpose'] != null ? pass['purpose']['name'] ?? 'N/A' : 'N/A'}'),
+                    subtitle: Column(
+                      crossAxisAlignment: CrossAxisAlignment.start,
+                      children: [
+                        Text('Applicant: ${pass['person_name'] ?? 'N/A'}'),
+                        Text('Status: ${pass['status'] ?? 'N/A'}'),
+                        Text(
+                            'Entry: ${pass['entry_time'] != null ? DateFormat('yyyy-MM-dd HH:mm').format(DateTime.parse(pass['entry_time'])) : 'N/A'}'),
+                      ],
+                    ),
+                    trailing: pass['status'] == 'PENDING'
+                        ? Row(
+                            mainAxisSize: MainAxisSize.min,
+                            children: [
+                              IconButton(
+                                icon: const Icon(Icons.check, color: Colors.green),
+                                onPressed: () => _approvePass(pass['id']),
+                              ),
+                              IconButton(
+                                icon: const Icon(Icons.close, color: Colors.red),
+                                onPressed: () => _rejectPass(pass['id']),
+                              ),
+                            ],
+                          )
+                        : null,
+                    onTap: () {
+                      Navigator.push(
+                        context,
+                        MaterialPageRoute(
+                          builder: (context) =>
+                              MyPassDetailsScreen(pass: pass),
+                        ),
+                      );
+                    },
+                  ),
+                );
+              },
+            ),
+          ),
+        ),
+      ],
+    );
+  }
+
+  Widget _buildFilterBar() {
+    return Padding(
+      padding: const EdgeInsets.all(8.0),
+      child: Row(
+        mainAxisAlignment: MainAxisAlignment.spaceEvenly,
+        children: [
+          _buildFilterButton('All'),
+          _buildFilterButton('PENDING'),
+          _buildFilterButton('APPROVED'),
+          _buildFilterButton('REJECTED'),
+        ],
+      ),
+    );
+  }
+
+  Widget _buildFilterButton(String status) {
+    return ElevatedButton(
+      onPressed: () => _filterPasses(status),
+      style: ElevatedButton.styleFrom(
+        backgroundColor:
+            _selectedStatus == status ? Theme.of(context).primaryColor : Colors.grey,
+      ),
+      child: Text(status),
+    );
+  }
+
+  void _filterPasses(String status) {
+    setState(() {
+      _selectedStatus = status;
+      if (status == 'All') {
+        _filteredGatePasses = _allGatePasses;
+      } else {
+        _filteredGatePasses =
+            _allGatePasses.where((pass) => pass['status'] == status).toList();
+      }
+    });
+  }
+}

--- a/frontend/gatepass_app/lib/presentation/home/home_screen.dart
+++ b/frontend/gatepass_app/lib/presentation/home/home_screen.dart
@@ -30,12 +30,14 @@ class _HomeScreenState extends State<HomeScreen> {
   late final AuthService _authService;
 
   late final List<Widget> _widgetOptions; // List of screens for the navigation
+  bool _isAdmin = false;
 
   @override
   void initState() {
     super.initState();
     _apiClient = widget.apiClient; // Assign from widget
     _authService = widget.authService; // Assign from widget
+    _checkAdminStatus();
 
     _widgetOptions = <Widget>[
       DashboardOverviewScreen(apiClient: _apiClient, authService: _authService),
@@ -44,7 +46,16 @@ class _HomeScreenState extends State<HomeScreen> {
       ProfileScreen(apiClient: _apiClient, authService: _authService),
       QrScannerScreen(apiClient: _apiClient),
       ReportsScreen(apiClient: _apiClient),
+      if (_isAdmin)
+        AdminScreen(apiClient: _apiClient, authService: _authService),
     ];
+  }
+
+  Future<void> _checkAdminStatus() async {
+    final isAdmin = await _authService.isAdmin();
+    setState(() {
+      _isAdmin = isAdmin;
+    });
   }
 
   void _onItemTapped(int index) {
@@ -120,6 +131,11 @@ class _HomeScreenState extends State<HomeScreen> {
             icon: Icon(Icons.bar_chart),
             label: 'Reports',
           ),
+          if (_isAdmin)
+            const BottomNavigationBarItem(
+              icon: Icon(Icons.admin_panel_settings),
+              label: 'Admin',
+            ),
         ],
         currentIndex: _selectedIndex,
         selectedItemColor: Theme.of(

--- a/frontend/gatepass_app/lib/services/auth_service.dart
+++ b/frontend/gatepass_app/lib/services/auth_service.dart
@@ -4,6 +4,7 @@ import 'dart:convert';
 import 'package:gatepass_app/core/api_client.dart'; // Ensure this is imported
 import 'package:shared_preferences/shared_preferences.dart';
 import 'package:flutter/foundation.dart'; // Import for debugPrint
+import 'package:jwt_decoder/jwt_decoder.dart';
 
 class AuthService {
   final SharedPreferences _prefs;
@@ -77,5 +78,19 @@ class AuthService {
   Future<bool> isLoggedIn() async {
     final accessToken = await getAccessToken();
     return accessToken != null && accessToken.isNotEmpty;
+  }
+
+  // --- Check if user is an admin ---
+  Future<bool> isAdmin() async {
+    final accessToken = await getAccessToken();
+    if (accessToken == null) {
+      return false;
+    }
+    try {
+      final Map<String, dynamic> decodedToken = JwtDecoder.decode(accessToken);
+      return decodedToken['is_staff'] ?? false;
+    } catch (e) {
+      return false;
+    }
   }
 }

--- a/frontend/gatepass_app/pubspec.yaml
+++ b/frontend/gatepass_app/pubspec.yaml
@@ -46,6 +46,8 @@ dependencies:
   screenshot: ^3.0.0
   share_plus: ^9.0.0
   printing: ^5.11.1
+  flutter_dotenv: ^5.1.0
+  jwt_decoder: ^2.0.1
 
 dev_dependencies:
   flutter_test:
@@ -74,6 +76,7 @@ flutter:
 
   assets:
     - assets/images/
+    - .env
 
   # To add assets to your application, add an assets section, like this:
   # assets:


### PR DESCRIPTION
This commit introduces a new screen for administrators to approve or reject gate passes. It also configures the application to use environment variables for sensitive data like the base URL and allowed hosts.

The `AuthService` has been updated to include an `isAdmin` method that checks if you have staff privileges by decoding the JWT token.

The `HomeScreen` now dynamically displays an "Admin" button in the bottom navigation bar for admin users.

The backend has been configured to use a `.env` file for the `ALLOWED_HOSTS` setting.

The frontend now uses a `.env` file for the `BASE_URL`.