### PR TITLE
feat: Add is_staff claim to JWT token

### DIFF
--- a/backend/apps/users/serializers.py
+++ b/backend/apps/users/serializers.py
@@ -1,7 +1,19 @@
 # backend/apps/users/serializers.py
 
 from rest_framework import serializers
-from .models import CustomUser # Assuming CustomUser is your user model
+from .models import CustomUser
+from rest_framework_simplejwt.serializers import TokenObtainPairSerializer
+
+class MyTokenObtainPairSerializer(TokenObtainPairSerializer):
+    @classmethod
+    def get_token(cls, user):
+        token = super().get_token(user)
+
+        # Add custom claims
+        token['username'] = user.username
+        token['is_staff'] = user.is_staff
+
+        return token
 
 class UserSerializer(serializers.ModelSerializer):
     class Meta:

--- a/backend/apps/users/views.py
+++ b/backend/apps/users/views.py
@@ -1,12 +1,15 @@
-# users/views.py (Excerpt)
 from rest_framework import generics, permissions
-from .serializers import UserSerializer # <--- Make sure this import is there
+from .serializers import UserSerializer, MyTokenObtainPairSerializer
 from django.contrib.auth import get_user_model
+from rest_framework_simplejwt.views import TokenObtainPairView
 
 User = get_user_model()
 
+class MyTokenObtainPairView(TokenObtainPairView):
+    serializer_class = MyTokenObtainPairSerializer
+
 class CurrentUserView(generics.RetrieveAPIView):
-    serializer_class = UserSerializer # <--- Make sure this is using your UserSerializer
+    serializer_class = UserSerializer
     permission_classes = [permissions.IsAuthenticated]
 
     def get_object(self):

--- a/backend/gatepass_project/urls.py
+++ b/backend/gatepass_project/urls.py
@@ -17,17 +17,17 @@ Including another URLconf
 from django.contrib import admin
 from django.urls import path, include
 from rest_framework_simplejwt.views import (
-    TokenObtainPairView,
     TokenRefreshView,
     TokenVerifyView,
 )
+from apps.users.views import MyTokenObtainPairView
 from django.conf import settings
 from django.conf.urls.static import static
 
 urlpatterns = [
     path('admin/', admin.site.urls),
     # JWT Authentication Endpoints
-    path('api/token/', TokenObtainPairView.as_view(), name='token_obtain_pair'),
+    path('api/token/', MyTokenObtainPairView.as_view(), name='token_obtain_pair'),
     path('api/token/refresh/', TokenRefreshView.as_view(), name='token_refresh'),
     path('api/token/verify/', TokenVerifyView.as_view(), name='token_verify'),
 


### PR DESCRIPTION
This commit customizes the JWT token to include the `is_staff` claim. This is necessary to identify admin users in the frontend and show them the admin screen.

A custom token serializer and view have been created to add the `is_staff` claim to the token.