### PR TITLE
fix: Reset selectedIndex on logout to prevent RangeError

### DIFF
--- a/frontend/gatepass_app/lib/presentation/home/home_screen.dart
+++ b/frontend/gatepass_app/lib/presentation/home/home_screen.dart
@@ -68,6 +68,9 @@ class _HomeScreenState extends State<HomeScreen> {
   void _logout() async {
     await _authService.logout();
     if (mounted) {
+      setState(() {
+        _selectedIndex = 0;
+      });
       // Use pushAndRemoveUntil to clear the stack and go to LoginScreen
       Navigator.of(context).pushAndRemoveUntil(
         MaterialPageRoute(


### PR DESCRIPTION
This commit fixes a `RangeError` that occurred in the `HomeScreen` when a user logged out and then logged in as a non-admin user.

The `_selectedIndex` is now reset to `0` in the `_logout` method to prevent the index from being out of bounds for the `_widgetOptions` list.