### PR TITLE
fix: Initialize widgetOptions in build to prevent RangeError

### DIFF
--- a/frontend/gatepass_app/lib/presentation/home/home_screen.dart
+++ b/frontend/gatepass_app/lib/presentation/home/home_screen.dart
@@ -30,7 +30,6 @@ class _HomeScreenState extends State<HomeScreen> {
   late final ApiClient _apiClient;
   late final AuthService _authService;
 
-  late final List<Widget> _widgetOptions; // List of screens for the navigation
   bool _isAdmin = false;
 
   @override
@@ -39,17 +38,6 @@ class _HomeScreenState extends State<HomeScreen> {
     _apiClient = widget.apiClient; // Assign from widget
     _authService = widget.authService; // Assign from widget
     _checkAdminStatus();
-
-    _widgetOptions = <Widget>[
-      DashboardOverviewScreen(apiClient: _apiClient, authService: _authService),
-      MyPassesScreen(apiClient: _apiClient, authService: _authService),
-      GatePassRequestScreen(apiClient: _apiClient, authService: _authService),
-      ProfileScreen(apiClient: _apiClient, authService: _authService),
-      QrScannerScreen(apiClient: _apiClient),
-      ReportsScreen(apiClient: _apiClient),
-      if (_isAdmin)
-        AdminScreen(apiClient: _apiClient, authService: _authService),
-    ];
   }
 
   Future<void> _checkAdminStatus() async {
@@ -84,6 +72,17 @@ class _HomeScreenState extends State<HomeScreen> {
 
   @override
   Widget build(BuildContext context) {
+    final List<Widget> _widgetOptions = <Widget>[
+      DashboardOverviewScreen(apiClient: _apiClient, authService: _authService),
+      MyPassesScreen(apiClient: _apiClient, authService: _authService),
+      GatePassRequestScreen(apiClient: _apiClient, authService: _authService),
+      ProfileScreen(apiClient: _apiClient, authService: _authService),
+      QrScannerScreen(apiClient: _apiClient),
+      ReportsScreen(apiClient: _apiClient),
+      if (_isAdmin)
+        AdminScreen(apiClient: _apiClient, authService: _authService),
+    ];
+
     return Scaffold(
       appBar: AppBar(
         // Set automaticallyImplyLeading to false to use our custom leading widget


### PR DESCRIPTION
This commit fixes a `RangeError` that occurred in the `HomeScreen` when a user logged out and then logged in as a non-admin user.

The initialization of the `_widgetOptions` list has been moved to the `build` method to ensure that the list is always up-to-date with the current value of the `_isAdmin` flag.