### PR TITLE
fix: Wrap filter buttons in Expanded to fix layout error

### DIFF
--- a/frontend/gatepass_app/lib/presentation/admin/admin_screen.dart
+++ b/frontend/gatepass_app/lib/presentation/admin/admin_screen.dart
@@ -195,10 +195,13 @@ class _AdminScreenState extends State<AdminScreen> {
       child: Row(
         mainAxisAlignment: MainAxisAlignment.spaceEvenly,
         children: [
-          _buildFilterButton('All'),
-          _buildFilterButton('PENDING'),
-          _buildFilterButton('APPROVED'),
-          _buildFilterButton('REJECTED'),
+          Expanded(child: _buildFilterButton('All')),
+          const SizedBox(width: 8),
+          Expanded(child: _buildFilterButton('PENDING')),
+          const SizedBox(width: 8),
+          Expanded(child: _buildFilterButton('APPROVED')),
+          const SizedBox(width: 8),
+          Expanded(child: _buildFilterButton('REJECTED')),
         ],
       ),
     );


### PR DESCRIPTION
This commit fixes a `BoxConstraints forces an infinite width` error in the `admin_screen.dart` file.

The `ElevatedButton` widgets in the `_buildFilterBar` method have been wrapped with `Expanded` widgets to ensure that they take up an equal amount of space in the `Row`.