### PR TITLE
fix: Add leading slash to API endpoints in AdminScreen

### DIFF
--- a/frontend/gatepass_app/lib/presentation/admin/admin_screen.dart
+++ b/frontend/gatepass_app/lib/presentation/admin/admin_screen.dart
@@ -50,7 +50,7 @@ class _AdminScreenState extends State<AdminScreen> {
       _errorMessage = null;
     });
     try {
-      final response = await _apiClient.get('api/gatepass/gatepasses/');
+      final response = await _apiClient.get('/api/gatepass/gatepasses/');
       _allGatePasses = _extractResults(response);
       _filteredGatePasses = _allGatePasses;
     } catch (e) {
@@ -66,7 +66,7 @@ class _AdminScreenState extends State<AdminScreen> {
 
   Future<void> _approvePass(int passId) async {
     try {
-      await _apiClient.post('api/gatepass/gatepasses/$passId/approve/', {});
+      await _apiClient.post('/api/gatepass/gatepasses/$passId/approve/', {});
       _fetchAllGatePasses();
     } catch (e) {
       ScaffoldMessenger.of(context).showSnackBar(
@@ -77,7 +77,7 @@ class _AdminScreenState extends State<AdminScreen> {
 
   Future<void> _rejectPass(int passId) async {
     try {
-      await _apiClient.post('api/gatepass/gatepasses/$passId/reject/', {});
+      await _apiClient.post('/api/gatepass/gatepasses/$passId/reject/', {});
       _fetchAllGatePasses();
     } catch (e) {
       ScaffoldMessenger.of(context).showSnackBar(


### PR DESCRIPTION
This commit fixes a bug where the API calls in the `AdminScreen` were failing due to missing leading slashes in the endpoints.