### PR TITLE
fix: Reduce dashboard icon size

### DIFF
--- a/frontend/gatepass_app/lib/presentation/dashboard/dashboard_overview_screen.dart
+++ b/frontend/gatepass_app/lib/presentation/dashboard/dashboard_overview_screen.dart
@@ -178,7 +178,7 @@ class _DashboardOverviewScreenState extends State<DashboardOverviewScreen> {
         child: Column(
           mainAxisAlignment: MainAxisAlignment.center,
           children: <Widget>[
-            Icon(icon, size: 40, color: color),
+            Icon(icon, size: 30, color: color),
             const SizedBox(height: 10),
             Text(
               title,


### PR DESCRIPTION
This commit reduces the size of the icons on the dashboard overview screen from 40 to 30 to address the issue of them being too large.