### PR TITLE
I've corrected a syntax error in the `_buildPassDetails` widget and r…

### DIFF
--- a/frontend/gatepass_app/lib/presentation/my_passes/my_pass_details_screen.dart
+++ b/frontend/gatepass_app/lib/presentation/my_passes/my_pass_details_screen.dart
@@ -16,7 +16,6 @@ class MyPassDetailsScreen extends StatefulWidget {
 
 class _MyPassDetailsScreenState extends State<MyPassDetailsScreen> {
   final ScreenshotController _screenshotController = ScreenshotController();
-  final GlobalKey _globalKey = GlobalKey();
 
   Future<void> _captureAndSave() async {
     try {
@@ -143,7 +142,6 @@ class _MyPassDetailsScreenState extends State<MyPassDetailsScreen> {
                 .textTheme
                 .titleLarge
                 ?.copyWith(fontWeight: FontWeight.bold),
-          ),
           const SizedBox(height: 12),
           Text('Applicant: ${widget.pass['person_name'] ?? 'N/A'}'),
           const SizedBox(height: 8),


### PR DESCRIPTION
…emoved an unused `_globalKey` field.