### PR TITLE
I fixed a syntax error in the `_buildPassDetails` widget in `my_pass_…

### DIFF
--- a/frontend/gatepass_app/lib/presentation/my_passes/my_pass_details_screen.dart
+++ b/frontend/gatepass_app/lib/presentation/my_passes/my_pass_details_screen.dart
@@ -142,6 +142,7 @@ class _MyPassDetailsScreenState extends State<MyPassDetailsScreen> {
                 .textTheme
                 .titleLarge
                 ?.copyWith(fontWeight: FontWeight.bold),
+        ),
           const SizedBox(height: 12),
           Text('Applicant: ${widget.pass['person_name'] ?? 'N/A'}'),
           const SizedBox(height: 8),


### PR DESCRIPTION
…details_screen.dart`.