### PR TITLE
Fix: Allow clientcare users to view all gate passes

### DIFF
--- a/IMPROVEMENT_PROPOSALS.md
+++ b/IMPROVEMENT_PROPOSALS.md
@@ -1,0 +1,74 @@
+# Gate Pass Management System: Improvement Proposals
+
+This document outlines a series of proposed improvements for the Gate Pass Management System, covering both the backend and frontend. The goal of these proposals is to enhance the application's functionality, security, performance, and maintainability, moving it towards a "world-class" standard.
+
+## Part 1: Backend Improvements
+
+The backend is built on Django and is well-structured. The following improvements focus on making it more robust, scalable, and feature-rich.
+
+### 1. Users App: Implement a Robust RBAC System
+
+*   **Problem**: The current system uses a hardcoded `role` field on the `CustomUser` model. This is inflexible and requires code changes to modify roles or permissions.
+*   **Proposal**: Replace the `role` field with Django's built-in `Group` and `Permission` models.
+*   **Benefits**:
+    *   **Scalability**: Easily add or modify roles and permissions through the Django admin interface without deploying new code.
+    *   **Granularity**: Assign specific permissions to groups (e.g., `gatepass.can_approve_pass`, `reports.can_view_summary`).
+    *   **Maintainability**: A more standard and maintainable way to handle authorization.
+
+### 2. Gatepass App: Add Advanced Features
+
+*   **Problem**: The current gate pass functionality is basic.
+*   **Proposals**:
+    *   **Pre-approved Visitor Lists**: Allow companies or departments to pre-approve a list of frequent visitors to expedite the check-in process.
+    *   **Recurring Gate Passes**: For employees, contractors, or long-term visitors, allow the creation of gate passes that are valid for a specified period (e.g., a week, a month).
+    *   **Gate Pass Templates**: Allow users to create templates for common types of gate passes to speed up creation.
+    *   **More Detailed Pass History**: Log all events related to a gate pass (creation, approval, rejection, edits, comments) for a complete audit trail.
+
+### 3. Gate Operations App: Enhance Security and Monitoring
+
+*   **Problem**: The gate operations are not logged in sufficient detail.
+*   **Proposals**:
+    *   **Detailed Logging**: Log every gate operation, including the timestamp, the security guard who performed the operation, the gate number, and the outcome.
+    *   **Real-time Monitoring Dashboard**: Create a dashboard for administrators to view real-time gate activity, see who is on-site, and receive security alerts.
+
+### 4. Reports App: Create Advanced and Customizable Reports
+
+*   **Problem**: The reporting capabilities are limited.
+*   **Proposals**:
+    *   **Advanced Reports**: Generate reports such as daily/monthly visitor summaries, driver performance reports, and security incident reports.
+    *   **Customizable Reports**: Allow users to filter reports by date range, pass type, status, and other criteria.
+    *   **Export Options**: Allow reports to be exported to PDF and CSV formats.
+    *   **Data Visualization**: Use charts and graphs to present data in an easily digestible format.
+
+### 5. General Backend Improvements
+
+*   **Comprehensive Test Suite**: The project lacks a comprehensive test suite. Adding unit, integration, and API tests is crucial for ensuring code quality and preventing regressions.
+*   **Caching**: Implement caching (e.g., with Redis) for frequently accessed data to improve API response times.
+*   **Logging and Monitoring**: Set up a robust logging and monitoring system (e.g., using the ELK stack or Sentry) to track errors and performance metrics.
+
+## Part 2: Frontend Improvements
+
+The frontend is a Flutter application. The following proposals focus on improving the user experience, performance, and stability.
+
+### 1. UI/UX Enhancements
+
+*   **Modern Design**: Refresh the UI with a more modern and intuitive design.
+*   **Improved Workflow**: Streamline the process of creating and managing gate passes.
+*   **Better Error Handling**: Provide clear and helpful error messages to the user.
+*   **Accessibility**: Ensure the app is accessible to users with disabilities by following the WCAG guidelines.
+
+### 2. New Features
+
+*   **Push Notifications**: Send push notifications to users when the status of their gate pass changes (e.g., approved, rejected).
+*   **Offline Support**: For security guards, the app should be able to scan QR codes and store the data locally when there is no internet connection. The data can then be synced to the server when the connection is restored.
+*   **Detailed Gate Pass View**: Provide a more detailed view of the gate pass, including the QR code, visitor details, pass history, and any associated documents.
+
+### 3. Performance Optimization
+
+*   **Code Splitting and Lazy Loading**: Reduce the app's initial load time by only loading the necessary code for the current screen.
+*   **Efficient State Management**: Use a robust state management solution (e.g., BLoC, Riverpod) to prevent unnecessary UI rebuilds.
+*   **Image Optimization**: Optimize images to reduce their size and improve loading times.
+
+### 4. Testing
+
+*   **Comprehensive Test Suite**: Add a full suite of widget and integration tests to ensure the UI is working as expected and the app is stable.

--- a/backend/apps/gatepass/views.py
+++ b/backend/apps/gatepass/views.py
@@ -61,7 +61,7 @@ class GatePassViewSet(viewsets.ModelViewSet):
 
     def get_queryset(self):
         user = self.request.user
-        if user.is_staff or user.is_superuser:
+        if user.is_staff or user.is_superuser or user.role == 'Client Care':
             return GatePass.objects.all()
         return GatePass.objects.filter(created_by=user)
 


### PR DESCRIPTION
I have fixed a bug where users in the 'clientcare' group could not see all gate passes. I modified the `get_queryset` method in the `GatePassViewSet` to include a check for the 'Client Care' role.

As you requested, I have also included a document with proposals for improving the application. The proposals cover both the backend and the frontend, and aim to enhance the application's functionality, security, performance, and maintainability.

The backend tests pass, but the frontend tests are failing. The failures seem to be related to the test environment and not the application code. I will need to investigate further to fix the frontend tests.