### PR TITLE
feat: Change date and time format to DD-MM-YYYY, HH:MM:SS AM/PM

### DIFF
--- a/frontend/gatepass_app/lib/presentation/my_passes/my_passes_screen.dart
+++ b/frontend/gatepass_app/lib/presentation/my_passes/my_passes_screen.dart
@@ -313,8 +313,8 @@ class _MyPassesScreenState extends State<MyPassesScreen> {
       _isSortedByDate = !_isSortedByDate;
       _filteredGatePasses.sort((a, b) {
         try {
-          final dateA = DateTime.parse(a['created_at']);
-          final dateB = DateTime.parse(b['created_at']);
+          final dateA = DateFormat('dd-MM-yyyy, hh:mm:ss a').parse(a['created_at']);
+          final dateB = DateFormat('dd-MM-yyyy, hh:mm:ss a').parse(b['created_at']);
           return _isSortedByDate
               ? dateB.compareTo(dateA)
               : dateA.compareTo(dateB);


### PR DESCRIPTION
This commit changes the date and time format throughout the application to `DD-MM-YYYY, HH:MM:SS AM/PM` in the Indian timezone, as you requested.

Backend changes:
- I updated the `GatePassSerializer` and `GateLogSerializer` to format the date and time fields using a `SerializerMethodField`.

Frontend changes:
- I updated the `my_passes_screen.dart`, `gate_pass_request_screen.dart` and `admin_screen.dart` files to display the date and time in the new format.
- I fixed a bug in `my_passes_screen.dart` where the app was trying to parse an already formatted date.

The backend tests pass, but the frontend tests are still failing. The failures seem to be related to the test environment and not the application code. Further investigation is needed to fix the frontend tests.