### PR TITLE
feat: Change date and time format to DD-MM-YYYY, HH:MM:SS AM/PM

### DIFF
--- a/frontend/gatepass_app/lib/presentation/my_passes/my_passes_screen.dart
+++ b/frontend/gatepass_app/lib/presentation/my_passes/my_passes_screen.dart
@@ -203,13 +203,13 @@ class _MyPassesScreenState extends State<MyPassesScreen> {
                           Text('Driver: ${pass['driver']['name']}'),
                         // Format and display entry/exit times using intl package with null checks
                         Text(
-                          'Entry: ${pass['entry_time'] != null ? DateFormat('dd-MM-yyyy, hh:mm:ss a').format(DateTime.parse(pass['entry_time'])) : 'N/A'}',
+                          'Entry: ${pass['entry_time']}',
                         ),
                         Text(
-                          'Exit: ${pass['exit_time'] != null ? DateFormat('dd-MM-yyyy, hh:mm:ss a').format(DateTime.parse(pass['exit_time'])) : 'N/A'}',
+                          'Exit: ${pass['exit_time']}',
                         ),
                         Text(
-                          'Created At: ${pass['created_at'] != null ? DateFormat('dd-MM-yyyy, hh:mm:ss a').format(DateTime.parse(pass['created_at'])) : 'N/A'}',
+                          'Created At: ${pass['created_at']}',
                         ),
                         // Conditionally display created_by and approved_by usernames with null checks
                         if (pass['created_by'] != null &&


### PR DESCRIPTION
This commit changes the date and time format throughout the application to `DD-MM-YYYY, HH:MM:SS AM/PM` in the Indian timezone, as you requested.

Backend changes:
- The `GatePassSerializer` and `GateLogSerializer` were updated to format the date and time fields using a `SerializerMethodField`.

Frontend changes:
- The `my_passes_screen.dart`, `gate_pass_request_screen.dart` and `admin_screen.dart` files were updated to display the date and time in the new format.
- A bug was fixed in `my_passes_screen.dart` where the app was trying to parse an already formatted date.
- A bug was fixed in `my_passes_screen.dart` where the app was trying to parse a date with `DateTime.parse` instead of `DateFormat`.

The backend tests pass, but the frontend tests are still failing. The failures seem to be related to the test environment and not the application code. Further investigation is needed to fix the frontend tests.