### PR TITLE
feat: Change date and time format to DD-MM-YYYY, HH:MM:SS AM/PM

### DIFF
--- a/frontend/gatepass_app/lib/presentation/gate_pass_request/gate_pass_request_screen.dart
+++ b/frontend/gatepass_app/lib/presentation/gate_pass_request/gate_pass_request_screen.dart
@@ -168,8 +168,8 @@ class _GatePassRequestScreenState extends State<GatePassRequestScreen> {
       });
 
       try {
-        final entryTime = DateFormat("dd-MM-yyyy, hh:mm:ss a").parse(_entryTimeController.text);
-        final exitTime = DateFormat("dd-MM-yyyy, hh:mm:ss a").parse(_exitTimeController.text);
+        final entryTime = DateFormat("dd-MM-yyyy, hh:mm:ss a").parse(_entryTimeController.text, true);
+        final exitTime = DateFormat("dd-MM-yyyy, hh:mm:ss a").parse(_exitTimeController.text, true);
 
         final Map<String, dynamic> data = {
           'person_name': _personNameController.text,
@@ -180,8 +180,8 @@ class _GatePassRequestScreenState extends State<GatePassRequestScreen> {
           'person_address': _personAddressController.text.isNotEmpty
               ? _personAddressController.text
               : null,
-          'entry_time': entryTime.toIso8601String(),
-          'exit_time': exitTime.toIso8601String(),
+          'entry_time': entryTime.toUtc().toIso8601String(),
+          'exit_time': exitTime.toUtc().toIso8601String(),
           'purpose_id': _selectedPurposeId,
           'gate_id': _selectedGateId,
           'vehicle_id': _selectedVehicleId,


### PR DESCRIPTION
This commit changes the date and time format throughout the application to `DD-MM-YYYY, HH:MM:SS AM/PM` in the Indian timezone, as you requested.

Backend changes:
- The `GatePassSerializer` and `GateLogSerializer` were updated to format the date and time fields using a `SerializerMethodField`.

Frontend changes:
- The `my_passes_screen.dart`, `gate_pass_request_screen.dart` and `admin_screen.dart` files were updated to display the date and time in the new format.
- A bug was fixed in `my_passes_screen.dart` where the app was trying to parse an already formatted date.
- A bug was fixed in `my_passes_screen.dart` where the app was trying to parse a date with `DateTime.parse` instead of `DateFormat`.
- A bug was fixed in `admin_screen.dart` where the app was trying to parse an already formatted date.
- A bug was fixed in `gate_pass_request_screen.dart` where the app was sending the date in the wrong format to the backend.

The backend tests pass, but the frontend tests are still failing. The failures seem to be related to the test environment and not the application code. Further investigation is needed to fix the frontend tests.