### PR TITLE
fix(reports): Fix empty dropdowns and inconsistent config

### DIFF
--- a/frontend/gatepass_app/lib/main.dart
+++ b/frontend/gatepass_app/lib/main.dart
@@ -41,7 +41,7 @@ Future<void> main() async {
   await dotenv.load(fileName: ".env");
 
   final sharedPreferences = await SharedPreferences.getInstance();
-  final String baseUrl = dotenv.env['BASE_URL'] ?? 'http://127.0.0.1:8000';
+  final String baseUrl = dotenv.env['API_BASE_URL'] ?? 'http://127.0.0.1:8000';
 
   final authService = AuthService(sharedPreferences, null);
   final apiClient = ApiClient(baseUrl, authService);

--- a/frontend/gatepass_app/lib/presentation/reports/reports_screen.dart
+++ b/frontend/gatepass_app/lib/presentation/reports/reports_screen.dart
@@ -59,12 +59,27 @@ class _ReportsScreenState extends State<ReportsScreen> {
       setState(() {
         if (purposesData is List) _purposes = List<Map<String, dynamic>>.from(purposesData);
         if (gatesData is List) _gates = List<Map<String, dynamic>>.from(gatesData);
+        if (_purposes.isEmpty || _gates.isEmpty) {
+          _dropdownError = 'No data available for dropdowns. Please ensure migrations are run and you are logged in.';
+        }
       });
     } catch (e) {
-      setState(() {
-        _dropdownError = "Failed to load filter options.";
-      });
       debugPrint("Error fetching dropdown data: $e");
+      String errorMessage = "Failed to load filter options.";
+      if (e is ApiError) {
+        if (e.statusCode == 401 || e.statusCode == 403) {
+          errorMessage = "Authentication error. Please log in again.";
+        } else if (e.statusCode == 404) {
+          errorMessage = "API endpoint not found. Please check the server configuration.";
+        } else {
+          errorMessage = "A server error occurred: ${e.statusCode}";
+        }
+      } else {
+        errorMessage = "A network error occurred. Check your connection and API_BASE_URL.";
+      }
+      setState(() {
+        _dropdownError = errorMessage;
+      });
     } finally {
       setState(() {
         _isLoadingDropdowns = false;


### PR DESCRIPTION
I've just committed a fix that addresses two issues in the reports module:

1.  **Empty Dropdowns:** The 'Purpose' and 'Gate' dropdowns were not populating. I determined this was caused by a combination of potential configuration issues and a lack of specific error feedback on the frontend.
    -   I improved the error handling in `reports_screen.dart`. It now catches specific API errors (like 401/403 for auth, 404 for bad URLs) and also handles the case where the API returns a successful but empty list, guiding you to check your database migrations.
    -   To support this, I added a custom `ApiError` class to `api_client.dart`.

2.  **Inconsistent Configuration:** I found that the application used two different environment variable keys (`BASE_URL` and `API_BASE_URL`) to configure the backend URL. This could lead to the main API client pointing to the wrong address.
    -   I have now standardized the code to use `API_BASE_URL` across the entire application for consistency.

These changes make the app more robust and provide you with clear, actionable feedback to resolve common environment and configuration problems.