### PR TITLE
debug(core_data): Add extensive logging to ViewSets

### DIFF
--- a/backend/apps/core_data/views.py
+++ b/backend/apps/core_data/views.py
@@ -3,9 +3,13 @@ from django.shortcuts import render
 # Create your views here.
 # backend/apps/core_data/views.py
 
+import logging
 from rest_framework import viewsets, permissions
 from .models import Gate, Purpose, VehicleType
 from .serializers import GateSerializer, PurposeSerializer, VehicleTypeSerializer
+
+# Get an instance of a logger
+logger = logging.getLogger(__name__)
 
 # Gate ViewSet - Accessible only by Admins/Staff
 class GateViewSet(viewsets.ModelViewSet):
@@ -13,11 +17,47 @@ class GateViewSet(viewsets.ModelViewSet):
     serializer_class = GateSerializer
     permission_classes = [permissions.IsAuthenticated] # Only authenticated users can manage gates
 
+    def list(self, request, *args, **kwargs):
+        logger.info("--- GateViewSet: list method called ---")
+        logger.info(f"Request User: {request.user}")
+
+        initial_queryset = self.get_queryset()
+        logger.info(f"Initial queryset count: {initial_queryset.count()}")
+
+        filtered_queryset = self.filter_queryset(initial_queryset)
+        logger.info(f"Filtered queryset count: {filtered_queryset.count()}")
+
+        # Log details of the filtered queryset if it's unexpectedly empty
+        if initial_queryset.exists() and not filtered_queryset.exists():
+            logger.warning("Queryset became empty after filtering!")
+            logger.warning(f"Filter backends configured for this view: {self.get_filter_backends()}")
+
+        return super().list(request, *args, **kwargs)
+
+
 # Purpose ViewSet - Accessible only by Admins/Staff
 class PurposeViewSet(viewsets.ModelViewSet):
     queryset = Purpose.objects.all()
     serializer_class = PurposeSerializer
     permission_classes = [permissions.IsAuthenticated] # Only authenticated users can manage purposes
+
+    def list(self, request, *args, **kwargs):
+        logger.info("--- PurposeViewSet: list method called ---")
+        logger.info(f"Request User: {request.user}")
+
+        initial_queryset = self.get_queryset()
+        logger.info(f"Initial queryset count: {initial_queryset.count()}")
+
+        filtered_queryset = self.filter_queryset(initial_queryset)
+        logger.info(f"Filtered queryset count: {filtered_queryset.count()}")
+
+        # Log details of the filtered queryset if it's unexpectedly empty
+        if initial_queryset.exists() and not filtered_queryset.exists():
+            logger.warning("Queryset became empty after filtering!")
+            logger.warning(f"Filter backends configured for this view: {self.get_filter_backends()}")
+
+        return super().list(request, *args, **kwargs)
+
 
 # VehicleType ViewSet - Accessible only by Admins/Staff
 class VehicleTypeViewSet(viewsets.ModelViewSet):


### PR DESCRIPTION
This commit adds temporary debugging logs to the `GateViewSet` and `PurposeViewSet` in the `core_data` app.

The purpose of this logging is to diagnose a persistent issue where the API returns an empty list for gates and purposes, despite the data being present in the database (as confirmed by a management command).

The overridden `list` method in each ViewSet will now log:
- The request user.
- The count of the initial queryset (`.get_queryset()`).
- The count of the queryset after filtering (`.filter_queryset()`).
- A warning if the queryset becomes empty after filtering, along with a list of any filter backends found.

This will provide crucial visibility into the request lifecycle and help pinpoint exactly where the data is being lost.