### PR TITLE
fix(reports): Correctly parse paginated API response in frontend

### DIFF
--- a/backend/apps/core_data/views.py
+++ b/backend/apps/core_data/views.py
@@ -3,13 +3,9 @@ from django.shortcuts import render
 # Create your views here.
 # backend/apps/core_data/views.py
 
-import logging
 from rest_framework import viewsets, permissions
 from .models import Gate, Purpose, VehicleType
 from .serializers import GateSerializer, PurposeSerializer, VehicleTypeSerializer
-
-# Get an instance of a logger
-logger = logging.getLogger(__name__)
 
 # Gate ViewSet - Accessible only by Admins/Staff
 class GateViewSet(viewsets.ModelViewSet):
@@ -17,47 +13,11 @@ class GateViewSet(viewsets.ModelViewSet):
     serializer_class = GateSerializer
     permission_classes = [permissions.IsAuthenticated] # Only authenticated users can manage gates
 
-    def list(self, request, *args, **kwargs):
-        logger.info("--- GateViewSet: list method called ---")
-        logger.info(f"Request User: {request.user}")
-
-        initial_queryset = self.get_queryset()
-        logger.info(f"Initial queryset count: {initial_queryset.count()}")
-
-        filtered_queryset = self.filter_queryset(initial_queryset)
-        logger.info(f"Filtered queryset count: {filtered_queryset.count()}")
-
-        # Log details of the filtered queryset if it's unexpectedly empty
-        if initial_queryset.exists() and not filtered_queryset.exists():
-            logger.warning("Queryset became empty after filtering!")
-            logger.warning(f"Filter backends configured for this view: {self.get_filter_backends()}")
-
-        return super().list(request, *args, **kwargs)
-
-
 # Purpose ViewSet - Accessible only by Admins/Staff
 class PurposeViewSet(viewsets.ModelViewSet):
     queryset = Purpose.objects.all()
     serializer_class = PurposeSerializer
     permission_classes = [permissions.IsAuthenticated] # Only authenticated users can manage purposes
-
-    def list(self, request, *args, **kwargs):
-        logger.info("--- PurposeViewSet: list method called ---")
-        logger.info(f"Request User: {request.user}")
-
-        initial_queryset = self.get_queryset()
-        logger.info(f"Initial queryset count: {initial_queryset.count()}")
-
-        filtered_queryset = self.filter_queryset(initial_queryset)
-        logger.info(f"Filtered queryset count: {filtered_queryset.count()}")
-
-        # Log details of the filtered queryset if it's unexpectedly empty
-        if initial_queryset.exists() and not filtered_queryset.exists():
-            logger.warning("Queryset became empty after filtering!")
-            logger.warning(f"Filter backends configured for this view: {self.get_filter_backends()}")
-
-        return super().list(request, *args, **kwargs)
-
 
 # VehicleType ViewSet - Accessible only by Admins/Staff
 class VehicleTypeViewSet(viewsets.ModelViewSet):

--- a/frontend/gatepass_app/lib/presentation/reports/reports_screen.dart
+++ b/frontend/gatepass_app/lib/presentation/reports/reports_screen.dart
@@ -57,8 +57,15 @@ class _ReportsScreenState extends State<ReportsScreen> {
       final purposesData = await widget.apiClient.get('/api/core-data/purposes/');
       final gatesData = await widget.apiClient.get('/api/core-data/gates/');
       setState(() {
-        if (purposesData is List) _purposes = List<Map<String, dynamic>>.from(purposesData);
-        if (gatesData is List) _gates = List<Map<String, dynamic>>.from(gatesData);
+        // Correctly parse the paginated response from DRF
+        if (purposesData is Map<String, dynamic> && purposesData.containsKey('results')) {
+          _purposes = List<Map<String, dynamic>>.from(purposesData['results']);
+        }
+        if (gatesData is Map<String, dynamic> && gatesData.containsKey('results')) {
+          _gates = List<Map<String, dynamic>>.from(gatesData['results']);
+        }
+
+        // After attempting to parse, check if the lists are empty.
         if (_purposes.isEmpty || _gates.isEmpty) {
           _dropdownError = 'No data available for dropdowns. Please ensure migrations are run and you are logged in.';
         }


### PR DESCRIPTION
This commit provides the definitive fix for the empty 'Gate' and 'Purpose' dropdowns in the reports module.

The root cause was a bug in the frontend's data fetching logic in `reports_screen.dart`. The code was expecting a simple list from the API, but the Django REST Framework backend was correctly returning a standard paginated response object (a map containing `count`, `next`, `previous`, and `results` keys). The frontend failed to parse this map, resulting in the dropdown lists remaining empty and an incorrect error message being displayed.

This commit corrects the parsing logic to properly extract the list of items from the `results` key of the API response.

This commit also includes the cumulative improvements from previous debugging attempts:
- A more robust UI for the reports screen filters, where dropdowns remain visible but disabled during loading or on error.
- A `check_data` Django management command for easier database diagnostics.
- Standardized use of the `API_BASE_URL` environment variable.
- Removal of temporary debugging code from the backend views.