### PR TITLE
hotfix(reports): Correct BarChart tooltip parameter

### DIFF
--- a/frontend/gatepass_app/lib/presentation/reports/reports_screen.dart
+++ b/frontend/gatepass_app/lib/presentation/reports/reports_screen.dart
@@ -508,7 +508,7 @@ class _ReportsScreenState extends State<ReportsScreen> {
                   ),
                   barTouchData: BarTouchData(
                     touchTooltipData: BarTouchTooltipData(
-                      tooltipBgColor: Colors.blueGrey,
+                      getTooltipColor: (group) => Colors.blueGrey,
                       getTooltipItem: (group, groupIndex, rod, rodIndex) {
                         String weekDay = labels[group.x.toInt()];
                         return BarTooltipItem(


### PR DESCRIPTION
This commit fixes a build error in the reports screen that was caused by using an incorrect parameter name (`tooltipBgColor`) in the `BarTouchTooltipData` widget from the `fl_chart` package.

The incorrect parameter has been replaced with the correct `getTooltipColor` callback, which is compatible with the version of the library being used (`0.68.0`). This resolves the compilation error and restores the intended tooltip functionality.