### PR TITLE
fix(reports): Standardize export URL routing

### DIFF
--- a/backend/apps/reports/urls.py
+++ b/backend/apps/reports/urls.py
@@ -3,12 +3,12 @@ from .views import ReportViewSet
 
 urlpatterns = [
     path('daily-summary/', ReportViewSet.as_view({'get': 'daily_visitor_summary'}), name='report-daily-summary'),
-    path('daily-summary-export/', ReportViewSet.as_view({'get': 'daily_visitor_summary_export'}), name='report-daily-summary-export'),
+    path('daily-summary/export/', ReportViewSet.as_view({'get': 'daily_visitor_summary_export'}), name='report-daily-summary-export'),
     path('monthly-summary/', ReportViewSet.as_view({'get': 'monthly_visitor_summary'}), name='report-monthly-summary'),
-    path('monthly-summary-export/', ReportViewSet.as_view({'get': 'monthly_visitor_summary_export'}), name='report-monthly-summary-export'),
+    path('monthly-summary/export/', ReportViewSet.as_view({'get': 'monthly_visitor_summary_export'}), name='report-monthly-summary-export'),
     path('driver-performance/', ReportViewSet.as_view({'get': 'driver_performance_report'}), name='report-driver-performance'),
-    path('driver-performance-export/', ReportViewSet.as_view({'get': 'driver_performance_report_export'}), name='report-driver-performance-export'),
+    path('driver-performance/export/', ReportViewSet.as_view({'get': 'driver_performance_report_export'}), name='report-driver-performance-export'),
     path('security-incidents/', ReportViewSet.as_view({'get': 'security_incident_report'}), name='report-security-incidents'),
-    path('security-incidents-export/', ReportViewSet.as_view({'get': 'security_incident_report_export'}), name='report-security-incidents-export'),
+    path('security-incidents/export/', ReportViewSet.as_view({'get': 'security_incident_report_export'}), name='report-security-incidents-export'),
     path('data-visualization/', ReportViewSet.as_view({'get': 'data_visualization'}), name='report-data-visualization'),
 ]

--- a/backend/apps/reports/views.py
+++ b/backend/apps/reports/views.py
@@ -34,7 +34,7 @@ class ReportViewSet(viewsets.GenericViewSet):
         }
         return Response(summary)
 
-    @action(detail=False, methods=['get'], url_path='daily-summary-export', url_name='daily-summary-export')
+    @action(detail=False, methods=['get'], url_path='daily-summary/export', url_name='daily-summary-export')
     def daily_visitor_summary_export(self, request):
         filterset = GatePassFilter(request.query_params, queryset=GatePass.objects.all())
         gate_passes = filterset.qs

--- a/frontend/gatepass_app/lib/presentation/reports/reports_screen.dart
+++ b/frontend/gatepass_app/lib/presentation/reports/reports_screen.dart
@@ -144,8 +144,8 @@ class _ReportsScreenState extends State<ReportsScreen> {
     final queryString = _buildQueryString(queryParams);
     // Reverting to using dotenv, but keeping the null-coalescing for safety.
     final baseUrl = dotenv.env['API_BASE_URL'] ?? 'http://127.0.0.1:8000';
-    // Corrected the URL endpoint from 'daily-summary/export/' to 'daily-summary-export/'
-    final url = Uri.parse('$baseUrl/api/reports/daily-summary-export/$queryString');
+    // Corrected the URL endpoint to be consistent with the new backend routing
+    final url = Uri.parse('$baseUrl/api/reports/daily-summary/export/$queryString');
 
     try {
       if (await canLaunchUrl(url)) {


### PR DESCRIPTION
This commit fixes a persistent 404 error on the report export feature by standardizing the URL structure.

Previously, the export URLs in `apps/reports/urls.py` were inconsistent. This commit updates all report export URLs to a consistent, nested pattern (e.g., `daily-summary/export/`).

The corresponding `@action` decorators in `views.py` and the URL construction in the frontend's `reports_screen.dart` have been updated to match this standardized structure. This ensures that the frontend and backend routing are perfectly aligned, resolving the 404 error.