### PR TITLE
fix(reports): Restructure export URLs to resolve routing conflict

### DIFF
--- a/backend/apps/reports/urls.py
+++ b/backend/apps/reports/urls.py
@@ -2,13 +2,16 @@ from django.urls import path
 from .views import ReportViewSet
 
 urlpatterns = [
+    # Data endpoints
     path('daily-summary/', ReportViewSet.as_view({'get': 'daily_visitor_summary'}), name='report-daily-summary'),
-    path('daily-summary/export/', ReportViewSet.as_view({'get': 'daily_visitor_summary_export'}), name='report-daily-summary-export'),
     path('monthly-summary/', ReportViewSet.as_view({'get': 'monthly_visitor_summary'}), name='report-monthly-summary'),
-    path('monthly-summary/export/', ReportViewSet.as_view({'get': 'monthly_visitor_summary_export'}), name='report-monthly-summary-export'),
     path('driver-performance/', ReportViewSet.as_view({'get': 'driver_performance_report'}), name='report-driver-performance'),
-    path('driver-performance/export/', ReportViewSet.as_view({'get': 'driver_performance_report_export'}), name='report-driver-performance-export'),
     path('security-incidents/', ReportViewSet.as_view({'get': 'security_incident_report'}), name='report-security-incidents'),
-    path('security-incidents/export/', ReportViewSet.as_view({'get': 'security_incident_report_export'}), name='report-security-incidents-export'),
     path('data-visualization/', ReportViewSet.as_view({'get': 'data_visualization'}), name='report-data-visualization'),
+
+    # Export endpoints (restructured)
+    path('export/daily-summary/', ReportViewSet.as_view({'get': 'daily_visitor_summary_export'}), name='report-daily-summary-export'),
+    path('export/monthly-summary/', ReportViewSet.as_view({'get': 'monthly_visitor_summary_export'}), name='report-monthly-summary-export'),
+    path('export/driver-performance/', ReportViewSet.as_view({'get': 'driver_performance_report_export'}), name='report-driver-performance-export'),
+    path('export/security-incidents/', ReportViewSet.as_view({'get': 'security_incident_report_export'}), name='report-security-incidents-export'),
 ]

--- a/backend/apps/reports/views.py
+++ b/backend/apps/reports/views.py
@@ -34,7 +34,7 @@ class ReportViewSet(viewsets.GenericViewSet):
         }
         return Response(summary)
 
-    @action(detail=False, methods=['get'], url_path='daily-summary/export', url_name='daily-summary-export')
+    @action(detail=False, methods=['get'], url_path='export/daily-summary', url_name='report-daily-summary-export')
     def daily_visitor_summary_export(self, request):
         filterset = GatePassFilter(request.query_params, queryset=GatePass.objects.all())
         gate_passes = filterset.qs
@@ -101,7 +101,7 @@ class ReportViewSet(viewsets.GenericViewSet):
         }
         return Response(summary)
 
-    @action(detail=False, methods=['get'], url_path='monthly-summary/export', url_name='monthly-summary-export')
+    @action(detail=False, methods=['get'], url_path='export/monthly-summary', url_name='monthly-summary-export')
     def monthly_visitor_summary_export(self, request):
         filterset = GatePassFilter(request.query_params, queryset=GatePass.objects.all())
         gate_passes = filterset.qs
@@ -158,7 +158,7 @@ class ReportViewSet(viewsets.GenericViewSet):
         ).order_by('-total_gate_passes')
         return Response(driver_performance)
 
-    @action(detail=False, methods=['get'], url_path='driver-performance/export', url_name='driver-performance-export')
+    @action(detail=False, methods=['get'], url_path='export/driver-performance', url_name='driver-performance-export')
     def driver_performance_report_export(self, request):
         filterset = GatePassFilter(request.query_params, queryset=GatePass.objects.all())
         gate_passes = filterset.qs
@@ -206,7 +206,7 @@ class ReportViewSet(viewsets.GenericViewSet):
         serializer = GateLogSerializer(incidents, many=True)
         return Response(serializer.data)
 
-    @action(detail=False, methods=['get'], url_path='security-incidents/export', url_name='security-incidents-export')
+    @action(detail=False, methods=['get'], url_path='export/security-incidents', url_name='security-incidents-export')
     def security_incident_report_export(self, request):
         filterset = GateLogFilter(request.query_params, queryset=GateLog.objects.filter(status='failure'))
         incidents = filterset.qs

--- a/frontend/gatepass_app/lib/presentation/reports/reports_screen.dart
+++ b/frontend/gatepass_app/lib/presentation/reports/reports_screen.dart
@@ -144,8 +144,8 @@ class _ReportsScreenState extends State<ReportsScreen> {
     final queryString = _buildQueryString(queryParams);
     // Reverting to using dotenv, but keeping the null-coalescing for safety.
     final baseUrl = dotenv.env['API_BASE_URL'] ?? 'http://127.0.0.1:8000';
-    // Corrected the URL endpoint to be consistent with the new backend routing
-    final url = Uri.parse('$baseUrl/api/reports/daily-summary/export/$queryString');
+    // URL endpoint has been restructured for clarity and to avoid routing conflicts
+    final url = Uri.parse('$baseUrl/api/reports/export/daily-summary/$queryString');
 
     try {
       if (await canLaunchUrl(url)) {


### PR DESCRIPTION
This commit fixes a persistent 404 error on the report export feature by restructuring the API URLs to be unambiguous.

The previous nested structure (`[report-name]/export/`) was causing a subtle routing issue. This has been changed to a flatter, more distinct structure: `export/[report-name]/`.

- All export URL patterns in `apps/reports/urls.py` have been updated.
- The `url_path` for all corresponding `@action` decorators in `apps/reports/views.py` has been updated to match.
- The frontend URL construction in `reports_screen.dart` has been updated to call the new, correct endpoint.

This change ensures the Django URL resolver can clearly distinguish between data endpoints and export endpoints, resolving the 404 error.