### PR TITLE
feat: Add QR Code Generation for Visitor Form

### DIFF
--- a/backend/apps/core_data/urls.py
+++ b/backend/apps/core_data/urls.py
@@ -2,12 +2,14 @@
 
 from rest_framework.routers import DefaultRouter
 from django.urls import path, include
-from .views import GateViewSet, PurposeViewSet # Make sure these are imported correctly
+from .views import GateViewSet, PurposeViewSet, VehicleTypeViewSet, generate_visitor_qr_code
 
 router = DefaultRouter()
 router.register(r'gates', GateViewSet)
 router.register(r'purposes', PurposeViewSet)
+router.register(r'vehicle-types', VehicleTypeViewSet)
 
 urlpatterns = [
     path('', include(router.urls)),
+    path('visitor-qr-code/', generate_visitor_qr_code, name='visitor-qr-code'),
 ]

--- a/backend/apps/core_data/views.py
+++ b/backend/apps/core_data/views.py
@@ -1,4 +1,8 @@
 from django.shortcuts import render
+import qrcode
+from django.http import HttpResponse
+from django.conf import settings
+from io import BytesIO
 
 # Create your views here.
 # backend/apps/core_data/views.py
@@ -24,3 +28,26 @@ class VehicleTypeViewSet(viewsets.ModelViewSet):
     queryset = VehicleType.objects.all()
     serializer_class = VehicleTypeSerializer
     permission_classes = [permissions.IsAuthenticated] # Only authenticated users can manage vehicle types
+
+def generate_visitor_qr_code(request):
+    # Construct the URL for the visitor form
+    visitor_form_url = f"{settings.FRONTEND_BASE_URL}/#/visitor-form"
+
+    # Generate the QR code
+    qr = qrcode.QRCode(
+        version=1,
+        error_correction=qrcode.constants.ERROR_CORRECT_L,
+        box_size=10,
+        border=4,
+    )
+    qr.add_data(visitor_form_url)
+    qr.make(fit=True)
+
+    img = qr.make_image(fill_color="black", back_color="white")
+
+    # Save the image to a byte buffer
+    buffer = BytesIO()
+    img.save(buffer, format="PNG")
+
+    # Return the image as an HTTP response
+    return HttpResponse(buffer.getvalue(), content_type="image/png")

--- a/backend/gatepass_project/settings/base.py
+++ b/backend/gatepass_project/settings/base.py
@@ -159,6 +159,9 @@ MEDIA_ROOT = BASE_DIR / 'media' # Directory for user uploaded media
 
 DEFAULT_AUTO_FIELD = 'django.db.models.BigAutoField'
 
+# Base URL for the frontend application
+FRONTEND_BASE_URL = os.getenv('FRONTEND_BASE_URL', 'http://localhost:3000')
+
 # REST Framework settings
 REST_FRAMEWORK = {
     'DEFAULT_AUTHENTICATION_CLASSES': (

--- a/frontend/gatepass_app/lib/core/api_client.dart
+++ b/frontend/gatepass_app/lib/core/api_client.dart
@@ -17,12 +17,12 @@ class ApiError implements Exception {
 }
 
 class ApiClient {
-  final String _baseUrl;
+  final String baseUrl;
   AuthService?
   _authService; // Made nullable to handle circular dependency during initialization
 
   // Constructor now requires baseUrl and AuthService instance (can be null initially)
-  ApiClient(this._baseUrl, this._authService);
+  ApiClient(this.baseUrl, this._authService);
 
   // Setter for AuthService, used to break circular dependency during initial app setup
   void setAuthService(AuthService service) {
@@ -48,7 +48,7 @@ class ApiClient {
 
   // --- GET Request ---
   Future<dynamic> get(String endpoint) async {
-    final url = Uri.parse('$_baseUrl$endpoint');
+    final url = Uri.parse('$baseUrl$endpoint');
     final headers = await _getHeaders();
 
     debugPrint('API GET Request to: $url');
@@ -68,7 +68,7 @@ class ApiClient {
     Map<String, dynamic> body, {
     String? customToken,
   }) async {
-    final url = Uri.parse('$_baseUrl$endpoint');
+    final url = Uri.parse('$baseUrl$endpoint');
     final headers = await _getHeaders(customToken: customToken);
 
     debugPrint('API POST Request to: $url');
@@ -93,7 +93,7 @@ class ApiClient {
     Map<String, dynamic> body, {
     String? customToken, // Corrected parameter name
   }) async {
-    final url = Uri.parse('$_baseUrl$endpoint');
+    final url = Uri.parse('$baseUrl$endpoint');
     final headers = await _getHeaders(
       customToken: customToken,
     ); // Corrected parameter name here too
@@ -116,7 +116,7 @@ class ApiClient {
 
   // --- DELETE Request ---
   Future<dynamic> delete(String endpoint, {String? customToken}) async {
-    final url = Uri.parse('$_baseUrl$endpoint');
+    final url = Uri.parse('$baseUrl$endpoint');
     final headers = await _getHeaders(customToken: customToken);
 
     debugPrint('API DELETE Request to: $url');

--- a/frontend/gatepass_app/lib/presentation/admin/generate_qr_screen.dart
+++ b/frontend/gatepass_app/lib/presentation/admin/generate_qr_screen.dart
@@ -1,0 +1,54 @@
+import 'package:flutter/material.dart';
+import 'package:gatepass_app/core/api_client.dart';
+
+class GenerateQRScreen extends StatelessWidget {
+  final ApiClient apiClient;
+
+  const GenerateQRScreen({super.key, required this.apiClient});
+
+  @override
+  Widget build(BuildContext context) {
+    // Construct the full URL for the image
+    final qrCodeUrl = '${apiClient.baseUrl}/api/core-data/visitor-qr-code/';
+
+    return Scaffold(
+      appBar: AppBar(
+        title: const Text('Visitor Form QR Code'),
+      ),
+      body: Center(
+        child: Padding(
+          padding: const EdgeInsets.all(20.0),
+          child: Column(
+            mainAxisAlignment: MainAxisAlignment.center,
+            children: [
+              Text(
+                'Scan this QR code to access the visitor form.',
+                style: Theme.of(context).textTheme.titleMedium,
+                textAlign: TextAlign.center,
+              ),
+              const SizedBox(height: 20),
+              InteractiveViewer(
+                child: Image.network(
+                  qrCodeUrl,
+                  loadingBuilder: (context, child, loadingProgress) {
+                    if (loadingProgress == null) return child;
+                    return const Center(child: CircularProgressIndicator());
+                  },
+                  errorBuilder: (context, error, stackTrace) {
+                    return const Icon(Icons.error, size: 100, color: Colors.red);
+                  },
+                ),
+              ),
+              const SizedBox(height: 20),
+              Text(
+                'URL: $qrCodeUrl',
+                style: Theme.of(context).textTheme.bodySmall,
+                textAlign: TextAlign.center,
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/frontend/gatepass_app/lib/presentation/home/home_screen.dart
+++ b/frontend/gatepass_app/lib/presentation/home/home_screen.dart
@@ -14,6 +14,7 @@ import 'package:gatepass_app/presentation/admin/admin_screen.dart';
 import 'package:gatepass_app/presentation/profile/profile_screen.dart';
 import 'package:gatepass_app/presentation/employee/visitor_requests_screen.dart';
 import 'package:gatepass_app/presentation/security/approved_visitors_screen.dart';
+import 'package:gatepass_app/presentation/admin/generate_qr_screen.dart';
 
 class HomeScreen extends StatefulWidget {
   final ApiClient apiClient;
@@ -105,6 +106,7 @@ class _HomeScreenState extends State<HomeScreen> {
         QrScannerScreen(apiClient: _apiClient),
         ReportsScreen(apiClient: _apiClient),
         AdminScreen(apiClient: _apiClient, authService: _authService),
+        GenerateQRScreen(apiClient: _apiClient),
       ]);
     } else if (userRole == 'Security') {
       widgetOptions.addAll([
@@ -140,6 +142,7 @@ class _HomeScreenState extends State<HomeScreen> {
         const NavigationDestination(icon: Icon(Icons.qr_code_scanner_outlined), selectedIcon: Icon(Icons.qr_code_scanner), label: 'Scan QR'),
         const NavigationDestination(icon: Icon(Icons.bar_chart_outlined), selectedIcon: Icon(Icons.bar_chart), label: 'Reports'),
         const NavigationDestination(icon: Icon(Icons.sensor_door_outlined), selectedIcon: Icon(Icons.sensor_door), label: 'Manage Passes'),
+        const NavigationDestination(icon: Icon(Icons.qr_code_2_outlined), selectedIcon: Icon(Icons.qr_code_2), label: 'Generate QR'),
       ]);
     } else if (userRole == 'Security') {
       navBarItems.addAll([


### PR DESCRIPTION
This commit introduces a new feature for administrators to generate a QR code that links to the public visitor pass submission form.

Features:
- A new backend API endpoint (`/api/core-data/visitor-qr-code/`) that dynamically generates and serves a PNG image of the QR code.
- The QR code's content is the URL to the frontend's visitor form, configurable via a new `FRONTEND_BASE_URL` setting in Django.
- A new screen in the Flutter application, accessible to administrators, that displays this QR code.
- A new navigation item on the home screen for administrators to access the QR code generation screen.
- The `ApiClient` in the Flutter app was slightly refactored to expose the `baseUrl` for constructing the image URL.