### PR TITLE
fix: Correct default URL for visitor QR code

### DIFF
--- a/backend/gatepass_project/settings/base.py
+++ b/backend/gatepass_project/settings/base.py
@@ -160,7 +160,7 @@ MEDIA_ROOT = BASE_DIR / 'media' # Directory for user uploaded media
 DEFAULT_AUTO_FIELD = 'django.db.models.BigAutoField'
 
 # Base URL for the frontend application
-FRONTEND_BASE_URL = os.getenv('FRONTEND_BASE_URL', 'http://localhost:3000')
+FRONTEND_BASE_URL = os.getenv('FRONTEND_BASE_URL', 'http://localhost:8000')
 
 # REST Framework settings
 REST_FRAMEWORK = {


### PR DESCRIPTION
The default value for the `FRONTEND_BASE_URL` setting was pointing to port 3000 instead of 8000. This change corrects the default value to ensure the generated QR code for the visitor form points to the correct local development URL.